### PR TITLE
Add GPT-2 demo notebook

### DIFF
--- a/examples/gpt2_demo.ipynb
+++ b/examples/gpt2_demo.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GPT-2 quick test\n",
+    "\n",
+    "This notebook shows how to load [GPT-2](https://huggingface.co/gpt2) with the `transformers` library and generate text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer, AutoModelForCausalLM\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained('gpt2')\n",
+    "model = AutoModelForCausalLM.from_pretrained('gpt2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = 'Once upon a time'\n",
+    "inputs = tokenizer(prompt, return_tensors='pt')\n",
+    "outputs = model.generate(**inputs, max_length=20)\n",
+    "print(tokenizer.decode(outputs[0], skip_special_tokens=True))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
## Summary
- add a simple notebook demonstrating GPT-2 text generation with transformers

## Testing
- `python -m json.tool examples/gpt2_demo.ipynb > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_688c29a8c9e48322835f5c8a52f98df2